### PR TITLE
Setup options

### DIFF
--- a/AspNetCore.Yandex.ObjectStorage/AspNetCore.Yandex.ObjectStorage.csproj
+++ b/AspNetCore.Yandex.ObjectStorage/AspNetCore.Yandex.ObjectStorage.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
   </ItemGroup>

--- a/AspNetCore.Yandex.ObjectStorage/AspNetCore.Yandex.ObjectStorage.csproj
+++ b/AspNetCore.Yandex.ObjectStorage/AspNetCore.Yandex.ObjectStorage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.10</Version>
+    <Version>0.1.0</Version>
     <Authors>Shumkin Alexandr</Authors>
     <Description>S3 API realisation for Yandex Object Storage</Description>
     <PackageProjectUrl>https://github.com/DubZero/AspNetCore.Yandex.ObjectStorage</PackageProjectUrl>
@@ -26,6 +26,12 @@
     <None Update="deploy.sh">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.configuration.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/AspNetCore.Yandex.ObjectStorage/YandexConfigurationDefaults.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexConfigurationDefaults.cs
@@ -1,0 +1,7 @@
+namespace AspNetCore.Yandex.ObjectStorage
+{
+    public class YandexConfigurationDefaults
+    {
+        
+    }
+}

--- a/AspNetCore.Yandex.ObjectStorage/YandexConfigurationDefaults.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexConfigurationDefaults.cs
@@ -1,7 +1,12 @@
 namespace AspNetCore.Yandex.ObjectStorage
 {
-    public class YandexConfigurationDefaults
+    public static class YandexConfigurationDefaults
     {
+        /// <summary>
+        /// Configuration section name required by this package.
+        /// </summary>
+        public const string DefaultSectionName = "YandexStorage";
+        
         
     }
 }

--- a/AspNetCore.Yandex.ObjectStorage/YandexConfigurationReader.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexConfigurationReader.cs
@@ -1,0 +1,7 @@
+namespace AspNetCore.Yandex.ObjectStorage
+{
+    public class YandexConfigurationReader
+    {
+        
+    }
+}

--- a/AspNetCore.Yandex.ObjectStorage/YandexConfigurationReader.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexConfigurationReader.cs
@@ -1,7 +1,33 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace AspNetCore.Yandex.ObjectStorage
 {
-    public class YandexConfigurationReader
+    public static class YandexConfigurationReaderExtension
     {
+        public static YandexStorageOptions GetYandexStorageOptions(this IConfiguration configuration)
+        {
+            var section = configuration.GetSection(YandexConfigurationDefaults.DefaultSectionName);
+            
+            return new YandexStorageOptions(section);
+        }
         
+        public static IServiceCollection LoadYandexStorageOptions(this IServiceCollection services, IConfiguration configuration)
+        {
+            var readedOptions = configuration.GetYandexStorageOptions();
+            
+            services.Configure<YandexStorageOptions>(options =>
+            {
+                options.BucketName = readedOptions.BucketName;
+                options.Location = readedOptions.Location;
+                options.AccessKey = readedOptions.AccessKey;
+                options.SecretKey = readedOptions.SecretKey;
+                options.Endpoint = readedOptions.Endpoint;
+                options.Protocol = readedOptions.Protocol;
+            });
+
+            return services;
+        }
     }
 }

--- a/AspNetCore.Yandex.ObjectStorage/YandexStorageExtension.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexStorageExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetCore.Yandex.ObjectStorage
@@ -12,6 +13,19 @@ namespace AspNetCore.Yandex.ObjectStorage
 
             services.Configure(setupAction);
             services.AddTransient<YandexStorageService>();
+        }
+        
+        public static void AddYandexObjectStorage(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            
+            services.LoadYandexStorageOptions(configuration).AddTransient<YandexStorageService>();
+        }
+
+        public static YandexStorageService CreateYandexObjectService(this YandexStorageOptions options)
+        {
+            return new YandexStorageService(options);
         }
     }
 

--- a/AspNetCore.Yandex.ObjectStorage/YandexStorageOptions.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexStorageOptions.cs
@@ -1,7 +1,26 @@
+using Microsoft.Extensions.Configuration;
+
 namespace AspNetCore.Yandex.ObjectStorage
 {
     public class YandexStorageOptions
     {
+
+        public YandexStorageOptions()
+        {
+            
+        }
+
+        public YandexStorageOptions(IConfigurationSection section)
+        {
+            BucketName = section.GetSection("Bucket").Value;
+            AccessKey = section.GetSection("AccessKey").Value;
+            SecretKey = section.GetSection("SecretKey").Value;
+
+            Protocol = section.GetSection("Protocol")?.Value ?? YandexStorageDefaults.Protocol;
+            Location = section.GetSection("Location")?.Value ?? YandexStorageDefaults.Location;
+            Endpoint = section.GetSection("Endpoint")?.Value ?? YandexStorageDefaults.EndPoint;
+        }
+        
         /// <summary>
         /// "http" or "https"
         /// </summary>

--- a/AspNetCore.Yandex.ObjectStorage/YandexStorageService.cs
+++ b/AspNetCore.Yandex.ObjectStorage/YandexStorageService.cs
@@ -29,6 +29,17 @@ namespace AspNetCore.Yandex.ObjectStorage
             _hostName = yandexStorageOptions.HostName;
         }
         
+        public YandexStorageService(YandexStorageOptions options)
+        {
+            _protocol = options.Protocol;
+            _bucketName = options.BucketName;
+            _location = options.Location;
+            _endpoint = options.Endpoint;
+            _accessKey = options.AccessKey;
+            _secretKey = options.SecretKey;
+            _hostName = options.HostName;
+        }
+        
         private HttpRequestMessage PrepareGetRequest()
         {
            

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -19,6 +19,13 @@ namespace Sample
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .ConfigureAppConfiguration((hostContext, config) =>
+                {
+                    IHostingEnvironment env = hostContext.HostingEnvironment;
+
+                    config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+                });
     }
 }

--- a/Sample/Startup.cs
+++ b/Sample/Startup.cs
@@ -6,26 +6,28 @@ using AspNetCore.Yandex.ObjectStorage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sample
 {
     public class Startup
     {
+        
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+        
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddOptions();
             
-            services.AddYandexObjectStorage(options =>
-            {
-                options.BucketName = "bucket";
-                options.Location = "location";
-                options.AccessKey = "aKey";
-                options.SecretKey = "sKey";
-                options.Endpoint = "endpoint";
-            });
+            services.AddYandexObjectStorage(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -4,5 +4,10 @@
       "Default": "Warning"
     }
   },
+  "YandexStorage" : {
+    "Bucket" : "your-bucket",
+    "AccessKey" : "your-access-key",
+    "SecretKey" : "your-secret-key"
+  },
   "AllowedHosts": "*"
 }

--- a/Tests/OptionsSetupTest.cs
+++ b/Tests/OptionsSetupTest.cs
@@ -51,6 +51,7 @@ namespace Tests
             Assert.AreEqual("http", yandexOptions.Protocol, "Protocol not configured");
             Assert.AreEqual("your-access-key", yandexOptions.AccessKey, "Access Key not configured");
             Assert.AreEqual("your-secret-key", yandexOptions.SecretKey, "Secret Key not configured");
+            Assert.AreEqual(YandexStorageDefaults.EndPoint, yandexOptions.Endpoint, "Endpoint Key not configured");
         }
     }
 }

--- a/Tests/OptionsSetupTest.cs
+++ b/Tests/OptionsSetupTest.cs
@@ -1,0 +1,7 @@
+namespace Tests
+{
+    public class OptionsSetupTest
+    {
+        
+    }
+}

--- a/Tests/OptionsSetupTest.cs
+++ b/Tests/OptionsSetupTest.cs
@@ -1,7 +1,56 @@
+using AspNetCore.Yandex.ObjectStorage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace Tests
 {
+    [TestClass]
     public class OptionsSetupTest
     {
+
+        public IConfigurationRoot GetConfiguration()
+        {
+            return new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .Build();
+        }
         
+        [TestMethod]
+        public void TestOptionsRead()
+        {
+            var config = GetConfiguration();
+
+            var options = config.GetYandexStorageOptions();
+
+            Assert.IsTrue(options.BucketName == "your-bucket");
+            Assert.IsTrue(options.Protocol == "http");
+        }
+        
+        [TestMethod]
+        public void InjectTest()
+        {
+            var config = GetConfiguration();
+            IServiceCollection services = new ServiceCollection();
+            
+            services.AddYandexObjectStorage(config);
+            
+            var provider = services.BuildServiceProvider();
+            var service = provider.GetService(typeof(YandexStorageService));
+            
+            Assert.IsNotNull(service, "service is null");
+            Assert.IsInstanceOfType(service, typeof(YandexStorageService), "type incorrect");
+            
+            var optionsService = (IOptions<YandexStorageOptions>)provider.GetService(typeof(IOptions<YandexStorageOptions>));
+
+            var yandexOptions = optionsService.Value;
+            
+            // Check options registration
+            Assert.AreEqual("your-bucket", yandexOptions.BucketName, "Bucket name not configured");
+            Assert.AreEqual("http", yandexOptions.Protocol, "Protocol not configured");
+            Assert.AreEqual("your-access-key", yandexOptions.AccessKey, "Access Key not configured");
+            Assert.AreEqual("your-secret-key", yandexOptions.SecretKey, "Secret Key not configured");
+        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
@@ -16,6 +17,22 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore.Yandex.ObjectStorage\AspNetCore.Yandex.ObjectStorage.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.configuration\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.configuration.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Tests/appsettings.json
+++ b/Tests/appsettings.json
@@ -7,7 +7,8 @@
   "YandexStorage" : {
     "Bucket" : "your-bucket",
     "AccessKey" : "your-access-key",
-    "SecretKey" : "your-secret-key"
+    "SecretKey" : "your-secret-key",
+    "Protocol" : "http"
   },
   "AllowedHosts": "*"
 }

--- a/Tests/appsettings.json
+++ b/Tests/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "YandexStorage" : {
+    "Bucket" : "your-bucket",
+    "AccessKey" : "your-access-key",
+    "SecretKey" : "your-secret-key"
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Added extension to load options from `IConfiguratiuonRoot` as:

`services.AddYandexObjectStorage(Configuration);`

by default, it reads a section with the name `YandexStorage`, for example, the section in appsettings.json below:

```
  "YandexStorage" : {
    "Bucket" : "your-bucket",
    "AccessKey" : "your-access-key",
    "SecretKey" : "your-secret-key",
    "Protocol" : "http"
  }
```